### PR TITLE
:gear: : Improve config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ npm install -g daily-cli
 $ daily-cli COMMAND
 running command...
 $ daily-cli (-v|--version|version)
-daily-cli/0.0.8 darwin-x64 node-v12.16.2
+daily-cli/0.0.10 darwin-x64 node-v12.16.2
 $ daily-cli --help [COMMAND]
 USAGE
   $ daily-cli COMMAND
@@ -105,7 +105,7 @@ DESCRIPTION
   Extra documentation goes here
 ```
 
-_See code: [src/commands/api-generator.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.8/src/commands/api-generator.js)_
+_See code: [src/commands/api-generator.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.10/src/commands/api-generator.js)_
 
 ## `daily-cli aws-accounts ACTION`
 
@@ -128,7 +128,7 @@ DESCRIPTION
   Allow administrating your AWS accounts
 ```
 
-_See code: [src/commands/aws-accounts.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.8/src/commands/aws-accounts.js)_
+_See code: [src/commands/aws-accounts.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.10/src/commands/aws-accounts.js)_
 
 ## `daily-cli configure`
 
@@ -149,7 +149,7 @@ DESCRIPTION
   Extra documentation goes here https://github.com/FlavioAandres/daily-cli
 ```
 
-_See code: [src/commands/configure.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.8/src/commands/configure.js)_
+_See code: [src/commands/configure.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.10/src/commands/configure.js)_
 
 ## `daily-cli github ACTION`
 
@@ -185,7 +185,7 @@ DESCRIPTION
      Required access: repo & delete_repo
 ```
 
-_See code: [src/commands/github.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.8/src/commands/github.js)_
+_See code: [src/commands/github.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.10/src/commands/github.js)_
 
 ## `daily-cli health`
 
@@ -217,7 +217,7 @@ EXAMPLES
   $ health -s github trello
 ```
 
-_See code: [src/commands/health.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.8/src/commands/health.js)_
+_See code: [src/commands/health.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.10/src/commands/health.js)_
 
 ## `daily-cli hello`
 
@@ -238,7 +238,7 @@ EXAMPLE
   $ daily-cli hello --name pecue
 ```
 
-_See code: [src/commands/hello.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.8/src/commands/hello.js)_
+_See code: [src/commands/hello.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.10/src/commands/hello.js)_
 
 ## `daily-cli help [COMMAND]`
 
@@ -273,5 +273,5 @@ DESCRIPTION
   Extra documentation goes here
 ```
 
-_See code: [src/commands/run.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.8/src/commands/run.js)_
+_See code: [src/commands/run.js](https://github.com/FlavioAandres/daily-cli/blob/v0.0.10/src/commands/run.js)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daily-cli",
   "description": "cli to make the developer life easier",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "author": "Flavio A @FlavioAandres",
   "bin": {
     "daily-cli": "./bin/run"
@@ -62,6 +62,7 @@
     "prepack": "oclif-dev manifest && oclif-dev readme",
     "test": "echo NO TESTS",
     "version": "oclif-dev readme && git add README.md",
-    "publish-version": "npm install && npm publish || true"
+    "publish-version": "npm install && npm publish || true",
+    "postinstall": "node ./src/hooks/postinstall.js"
   }
 }

--- a/src/helpers/config.js
+++ b/src/helpers/config.js
@@ -1,9 +1,12 @@
 const fs = require('fs')
 const path = require('path')
+const os = require('os')
+const cliPackage = require('../../package.json')
+const defaultConfig = require('../configs/default.json')
 
 module.exports = class Config {
-    DEFAULT_CONFIG_FILE_PATH = './../configs/default.json'
-    DEFAULT_CONFIG_NAME = 'default'
+    DEFAULT_CONFIG_FILE_DIR = path.join(os.homedir(), '.config', cliPackage.name)
+    DEFAULT_CONFIG_FILE_PATH = path.join(os.homedir(), '.config', cliPackage.name, 'default.json')
     configuration = {}
 
     constructor() {
@@ -22,14 +25,14 @@ module.exports = class Config {
             if (!this.configuration[command]) {
                 this.configuration[command] = {}
             }
-            
-            if(typeof value === 'object'){
+
+            if (typeof value === 'object') {
                 this.configuration[command][key] = {}
                 Object.assign(this.configuration[command][key], value)
-            }else{
+            } else {
                 this.configuration[command][key] = value;
             }
-                
+
             this.createFile()
 
             return true
@@ -41,18 +44,20 @@ module.exports = class Config {
 
     loadConfig = () => {
         this.configuration =
-            fs.existsSync(path.join(__dirname, this.DEFAULT_CONFIG_FILE_PATH)) &&
+            fs.existsSync(this.DEFAULT_CONFIG_FILE_PATH) &&
             require(this.DEFAULT_CONFIG_FILE_PATH);
         if (!this.configuration) {
-            this.configuration = {};
-            this.createFile({})
+            this.configuration = defaultConfig;
+            this.createFile()
         }
     }
 
     createFile = () => {
-        const obsolutePath = path.join(__dirname, `/../configs/${this.DEFAULT_CONFIG_NAME}.json`)
+        if (!fs.existsSync(this.DEFAULT_CONFIG_FILE_DIR)) {
+            fs.mkdirSync(this.DEFAULT_CONFIG_FILE_DIR, { recursive: true })
+        }
         fs.writeFileSync(
-            obsolutePath,
+            this.DEFAULT_CONFIG_FILE_PATH,
             JSON.stringify(this.configuration, null, 5)
         );
     }

--- a/src/hooks/postinstall.js
+++ b/src/hooks/postinstall.js
@@ -1,0 +1,10 @@
+const { Config } = require('../helpers')
+
+/** 
+ * 
+ * This will handle the Load Config by default
+ * if the file not exists will create the config file with the default information;
+ * if the file exists will remain
+ */
+
+new Config()


### PR DESCRIPTION
Fix #31 

With this change the CLI will start to save the config default file on the directories:

**MacOs / Linux** : `~/.config/daily-cli/`
**Windows**: `C:\Users\<CURRENTUSER>\.config\daily-cli\`

-------

**Default config name**: `default.json`

-------
After the installation, NPM will run the post-install script located at src/hooks/postinstall.js, creating a Config object that will try to load the config by default, if the file not exists will create the configuration with the default config located at src/config/default.json


## How to try it on development?

1. Delete the config file if exists [SEE PATHS].
2. execute `npm run postinstall`.
3. Verify the config file [SEE PATHS].
4. Configure any command.
5. Verify the config file [SEE PATHS] and confirm your new setting.
6. execute `npm run postinstall` again, and verify that your settings are remaining.


